### PR TITLE
Fix coding error in invalidateDependentFiles()

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ function invalidateDependentFiles(cacheObjects, invalidatedModules, done) {
 
   invalidateModifiedFiles(mtimes, Object.keys(dependentFiles), function(dependentFile) {
     Object.keys(dependentFiles[dependentFile]).forEach(function(module) {
-      delete cache[module];
+      delete cacheObjects.modules[module];
     })
   }, function(err, invalidated, deleted) { done(err); });
 }


### PR DESCRIPTION
Delete module path from cacheObjects.modules, instead of cache, which is
actually undefined.

Test code added for coverage (the test would now fail if run against the
original code), but I didn't find out how to assert that the module was
actually rebuilt.
