### PR TITLE
fix assertions for required options

### DIFF
--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -22,8 +22,8 @@ function BrowserifyCache(b, opts) {
   if (BrowserifyCache.getCache(b)) return b; // already attached
 
   // certain opts must have been set when browserify instance was created
-  assert(b._options.fullPaths, "required browserify 'fullPaths' opt not set");
-  assert(b._options.cache, "required browserify 'cache' opt not set");
+  assert(b._options.fullPaths != null, "required browserify 'fullPaths' opt not set");
+  assert(b._options.cache != null, "required browserify 'cache' opt not set");
 
   // load cache from file specified by cacheFile opt
   var cacheFile = opts.cacheFile || opts.cachefile || b._options && b._options.cacheFile || null;


### PR DESCRIPTION
heya, :cat: 

this PR fixes the assertions for required options by checking that the option is not equal to `null` or `undefined` instead of checking if it is falsy. my motivation for this change is to use `fullPaths === false` which otherwise breaks.

cheers!
