### PR TITLE
Fix cache mtimes not being populated on first run

### DIFF
--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -175,7 +175,9 @@ function attachCachePersistHandler(b, cacheFile) {
       removeCacheBlocker(b);
     });
     // We need to wait until the cache is done being populated.
-    b.on('_cacheReadyToWrite', function() {
+    // Use .once because the `b` browserify object can be re-used for multiple
+    // bundles. We only want to save the cache once per bundle call.
+    b.once('_cacheReadyToWrite', function() {
       storeCache(b, cacheFile);
     });
   });

--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -7,6 +7,7 @@ var through = require('through2');
 var async = require('async');
 var assign = require('xtend/mutable');
 
+var assert = require('assert');
 var assertExists = require('./assertExists');
 var proxyEvent = require('./proxyEvent');
 var Cache = require('./Cache');
@@ -68,6 +69,18 @@ BrowserifyCache.getPackageCache = function(b) {
   }, {});
 };
 
+function addCacheBlocker(b) {
+  b.__cacheBlockerCount = (b.__cacheBlockerCount||0) + 1;
+}
+
+function removeCacheBlocker(b) {
+  assert(b.__cacheBlockerCount >= 1);
+  b.__cacheBlockerCount -= 1;
+  if (b.__cacheBlockerCount === 0) {
+    b.emit('_cacheReadyToWrite');
+  }
+}
+
 function attachCacheHooksToPipeline(b) {
   var cache = BrowserifyCache.getCache(b);
 
@@ -107,46 +120,60 @@ function invalidateCacheBeforeBundling(b, done) {
 
 function attachCacheDiscoveryHandlers(b) {
   b.on('dep', function(dep) {
-    updateCacheOnDep(b, dep);
+    addCacheBlocker(b);
+    updateCacheOnDep(b, dep, function(err) {
+      removeCacheBlocker(b);
+    });
   });
 
   b.on('transform', function(transformStream, moduleFile) {
     transformStream.on('file', function(dependentFile) {
-      updateCacheOnTransformFile(b, moduleFile, dependentFile);
+      addCacheBlocker(b);
+      updateCacheOnTransformFile(b, moduleFile, dependentFile, function(err) {
+        removeCacheBlocker(b);
+      });
     });
   });
 }
 
-function updateCacheOnDep(b, dep) {
+function updateCacheOnDep(b, dep, done) {
   var cache = BrowserifyCache.getCache(b);
   var file = dep.file || dep.id;
   if (typeof file === 'string') {
     if (dep.source != null) {
       cache.modules[file] = dep;
-      if (!cache.mtimes[file]) updateMtime(cache.mtimes, file);
+      if (!cache.mtimes[file])
+        return updateMtime(cache.mtimes, file, done);
     } else {
       console.warn('missing source for dep', file);
     }
   } else {
     console.warn('got dep missing file or string id', file);
   }
+  done();
 }
 
-function updateCacheOnTransformFile(b, moduleFile, dependentFile) {
+function updateCacheOnTransformFile(b, moduleFile, dependentFile, done) {
   var cache = BrowserifyCache.getCache(b);
   if (cache.dependentFiles[dependentFile] == null) {
     cache.dependentFiles[dependentFile] = {};
   }
   cache.dependentFiles[dependentFile][moduleFile] = true;
-  if (!cache.mtimes[dependentFile]) updateMtime(cache.mtimes, dependentFile);
+  if (!cache.mtimes[dependentFile])
+    return updateMtime(cache.mtimes, dependentFile, done);
+  done();
 }
 
 function attachCachePersistHandler(b, cacheFile) {
   if (!cacheFile) return;
 
   b.on('bundle', function(bundleStream) {
-    // store on completion
+    addCacheBlocker(b);
     bundleStream.on('end', function() {
+      removeCacheBlocker(b);
+    });
+    // We need to wait until the cache is done being populated.
+    b.on('_cacheReadyToWrite', function() {
       storeCache(b, cacheFile);
     });
   });
@@ -177,15 +204,14 @@ function loadCacheData(b, cacheFile) {
   return cacheData;
 }
 
-function updateMtime(mtimes, file) {
+function updateMtime(mtimes, file, done) {
   assertExists(mtimes);
   assertExists(file);
 
-  // Done synchronously so that mtimes is updated before the cache is saved.
-  try {
-    var stat = fs.statSync(file);
-    mtimes[file] = stat.mtime.getTime();
-  } catch(err) {}
+  fs.stat(file, function(err, stat) {
+    if (!err) mtimes[file] = stat.mtime.getTime();
+    done();
+  });
 }
 
 module.exports = BrowserifyCache;

--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -122,6 +122,7 @@ function attachCacheDiscoveryHandlers(b) {
   b.on('dep', function(dep) {
     addCacheBlocker(b);
     updateCacheOnDep(b, dep, function(err) {
+      if (err) b.emit('error', err);
       removeCacheBlocker(b);
     });
   });
@@ -130,6 +131,7 @@ function attachCacheDiscoveryHandlers(b) {
     transformStream.on('file', function(dependentFile) {
       addCacheBlocker(b);
       updateCacheOnTransformFile(b, moduleFile, dependentFile, function(err) {
+        if (err) b.emit('error', err);
         removeCacheBlocker(b);
       });
     });

--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -28,7 +28,7 @@ function BrowserifyCache(b, opts) {
   // load cache from file specified by cacheFile opt
   var cacheFile = opts.cacheFile || opts.cachefile || b._options && b._options.cacheFile || null;
   var cacheData = loadCacheData(b, cacheFile);
-  
+
   // b._options.cache is a shared object into which loaded module cache is merged.
   // it will be reused for each build, and mutated when the cache is invalidated.
   assign(b._options.cache, cacheData.modules);
@@ -37,7 +37,7 @@ function BrowserifyCache(b, opts) {
   var cache = Cache(cacheData);
   BrowserifyCache.setCache(b, cache);
 
-  attachCacheHooksToPipeline(b);  
+  attachCacheHooksToPipeline(b);
   attachCacheDiscoveryHandlers(b);
   attachCachePersistHandler(b, cacheFile);
 
@@ -181,9 +181,11 @@ function updateMtime(mtimes, file) {
   assertExists(mtimes);
   assertExists(file);
 
-  fs.stat(file, function(err, stat) {
-    if (!err) mtimes[file] = stat.mtime.getTime();
-  });
+  // Done synchronously so that mtimes is updated before the cache is saved.
+  try {
+    var stat = fs.statSync(file);
+    mtimes[file] = stat.mtime.getTime();
+  } catch(err) {}
 }
 
 module.exports = BrowserifyCache;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/jsdf/browserify-cache-api.git"
   },
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.2",
     "labeled-stream-splicer": "^1.0.2",
     "through2": "^0.6.3",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-cache-api",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.3",
+    "rimraf": "^2.5.2",
     "tap": "^0.7.1"
   }
 }

--- a/test/build.js
+++ b/test/build.js
@@ -1,5 +1,5 @@
 var test = require('tap').test
-var exec = require('child_process').exec
+var execFile = require('child_process').execFile
 var path = require('path')
 var through = require('through2')
 var fs = require('fs')
@@ -13,7 +13,7 @@ var dependentFile = path.join(outputdir, 'dependent.txt')
 
 test("make sure it builds and builds again", function (t) {
   // t.plan(5)
-  exec('mkdir -p '+outputdir, function (err) {
+  execFile('mkdir', ['-p', outputdir], function (err) {
     t.notOk(err, 'dir created')
     fs.writeFileSync(requiresDynamicModule, 'require("./dynamic")')
     build1()

--- a/test/build.js
+++ b/test/build.js
@@ -4,6 +4,7 @@ var path = require('path')
 var through = require('through2')
 var fs = require('fs')
 var xtend = require('xtend')
+var rimraf = require('rimraf')
 
 var basedir = path.resolve(__dirname, '../')
 var outputdir = path.join(basedir, 'example','output','test','build')
@@ -13,10 +14,13 @@ var dependentFile = path.join(outputdir, 'dependent.txt')
 
 test("make sure it builds and builds again", function (t) {
   // t.plan(5)
-  execFile('mkdir', ['-p', outputdir], function (err) {
-    t.notOk(err, 'dir created')
-    fs.writeFileSync(requiresDynamicModule, 'require("./dynamic")')
-    build1()
+  rimraf(outputdir, {disableGlob:true}, function (err) {
+    t.notOk(err, 'dir removed')
+    execFile('mkdir', ['-p', outputdir], function (err) {
+      t.notOk(err, 'dir created')
+      fs.writeFileSync(requiresDynamicModule, 'require("./dynamic")')
+      build1()
+    })
   })
 
   function build1 () {

--- a/test/build.js
+++ b/test/build.js
@@ -13,7 +13,8 @@ var requiresDynamicModule = path.join(outputdir, 'requires-dynamic.js')
 var dependentFile = path.join(outputdir, 'dependent.txt')
 
 test("make sure it builds and builds again", function (t) {
-  // t.plan(5)
+  t.plan(7)
+
   rimraf(outputdir, {disableGlob:true}, function (err) {
     t.notOk(err, 'dir removed')
     execFile('mkdir', ['-p', outputdir], function (err) {


### PR DESCRIPTION
This fixes https://github.com/jsdf/browserify-incremental/issues/8.

Browserify-cache-api's tests would have caught the issue, except that the tests don't start with an empty cache. (Well, the tests do catch the issue the first time.) This fixes the test so it always starts with an empty cache folder, and now it correctly detects https://github.com/jsdf/browserify-incremental/issues/8.

The cause was that the cache could be written to before `updateMtime` finished. I've changed it so that now there's a count of pending operations (`b.__cacheBlockerCount`) that need to be finished before the cache is written to. (I could have made `updateMtime` synchronous, and you might notice I originally fixed it that way, but I think it's good to embrace asynchronousness, especially if maybe in the future we're coordinating with other asynchronous actions too.)

Also I fixed a bug where the tests wouldn't work if your path had any spaces in it.
