### PR TITLE
Add tests updating dependent file, and handling de-duped modules

### DIFF
--- a/test/build.js
+++ b/test/build.js
@@ -11,20 +11,19 @@ var dependentFile = path.join(testUtils.testOutputDir, 'dependent.txt');
 
 // TODO: break this into a multiple tests
 // currently it tests that cache is used, and also that dependencies from the
-// 'transform' event are used for invalidating cache (incomplete)
+// 'transform' event are used for invalidating cache
 test('make sure it builds a valid bundle when using cache', function(t) {
-  t.plan(7);
+  t.plan(11);
 
   testUtils.cleanupTestOutputDir((err) => {
     t.notOk(err, 'clean up test output dir');
-
-    t.notOk(err, 'dir created');
     fs.writeFileSync(requiresDynamicModule, 'require("./dynamic")');
     build1();
   });
 
   function build1() {
     fs.writeFileSync(dynamicModule, 'console.log("a")');
+    fs.writeFileSync(dependentFile, 'foobar1');
 
     var b1 = configureBrowserify(testUtils.makeBrowserify());
 
@@ -44,8 +43,9 @@ test('make sure it builds a valid bundle when using cache', function(t) {
 
     var b2 = configureBrowserify(testUtils.makeBrowserify());
 
-    b2.on('changedDeps', function(invalidated) {
+    b2.on('changedDeps', function(invalidated, deleted) {
       t.ok(invalidated && invalidated.length == 1, 'one file changed');
+      t.ok(deleted && deleted.length == 0, 'nothing deleted');
     });
 
     b2.bundle()
@@ -56,24 +56,33 @@ test('make sure it builds a valid bundle when using cache', function(t) {
       })
       .pipe(fs.createWriteStream(path.join(testUtils.testOutputDir, 'build2.js')))
       .on('finish', () => {
+        var build2 = fs.readFileSync(path.join(testUtils.testOutputDir, 'build2.js'), 'utf8');
+        t.ok(build2.indexOf('console.log("b")') >= 0, 'bundle has new contents');
+
         testUtils.waitForMtimeTick(build3);
       });
   }
 
   function build3() {
     // dependentFile is changed
-    fs.writeFileSync(dependentFile, 'hello');
+    fs.writeFileSync(dependentFile, 'foobar2');
 
     var b3 = configureBrowserify(testUtils.makeBrowserify());
 
+    b3.on('changedDeps', function(invalidated, deleted) {
+      t.ok(invalidated.length == 0, 'nothing changed');
+      t.ok(deleted.length == 0, 'nothing deleted');
+    });
+
     b3.bundle()
       .pipe(through())
+      .pipe(fs.createWriteStream(path.join(testUtils.testOutputDir, 'build3.js')))
       .on('finish', () => {
         t.ok(true, 'built thrice');
-        // TODO: add assertion that dynamicModule was invalidated
+        var build3 = fs.readFileSync(path.join(testUtils.testOutputDir, 'build3.js'), 'utf8');
+        t.ok(build3.indexOf('foobar2') >= 0, 'bundle has new contents');
         t.end();
-      })
-      .pipe(fs.createWriteStream(path.join(testUtils.testOutputDir, 'build3.js')));
+      });
   }
 });
 
@@ -86,7 +95,12 @@ function configureBrowserify(b) {
       return through();
 
     return through(function(chunk, enc, cb) {
-      this.push(chunk);
+      var combined = new Buffer(
+        chunk.toString() + '\nconsole.log("dependent.txt:", ' +
+        JSON.stringify(fs.readFileSync(dependentFile, 'utf8')) +
+        ');\n'
+      );
+      this.push(combined);
       this.emit('file', dependentFile);
       cb();
     });

--- a/test/dedupe.js
+++ b/test/dedupe.js
@@ -1,0 +1,55 @@
+var test = require('tap').test;
+var path = require('path');
+var through = require('through2');
+var fs = require('fs');
+
+var testUtils = require('../support/testUtils');
+
+var mainEntry = path.join(testUtils.testOutputDir, 'index.js');
+var aJs = path.join(testUtils.testOutputDir, 'a.js');
+var bJs = path.join(testUtils.testOutputDir, 'b.js');
+
+test('it handles de-duped modules correctly', (t) => {
+  t.plan(5);
+
+  testUtils.cleanupTestOutputDir((err) => {
+    t.notOk(err, 'clean up test output dir');
+
+    fs.writeFileSync(mainEntry, 'require("./a"); require("./b");');
+    fs.writeFileSync(aJs, 'console.log("foo123");');
+    fs.writeFileSync(bJs, 'console.log("foo123");');
+
+    var build1 = path.join(testUtils.testOutputDir, 'build1.js');
+    var build2 = path.join(testUtils.testOutputDir, 'build2.js');
+
+    doBuild(build1, () => {
+      t.ok(true, 'built once');
+
+      var matches = fs.readFileSync(build1, 'utf8').match(/foo123/g);
+      t.ok(matches && matches.length === 1, 'bundle has correct de-duped contents');
+
+      fs.writeFileSync(aJs, 'console.log("foo456");');
+
+      doBuild(build2, () => {
+        t.ok(true, 'built twice');
+
+        var matches = fs.readFileSync(build2, 'utf8').match(/foo456/g);
+        t.ok(matches && matches.length === 1, 'bundle has updated un-de-duped contents');
+
+        t.end();
+      });
+    });
+  });
+
+  function doBuild(filepath, done) {
+    var b = testUtils.makeBrowserify();
+    b.add(mainEntry);
+
+    b.bundle()
+      .pipe(through())
+      .pipe(fs.createWriteStream(filepath))
+      .on('finish', () => {
+        testUtils.waitForMtimeTick(done);
+      });
+  }
+});


### PR DESCRIPTION
This tests that updating a dependent file invalidates the cache correctly (implementing that old TODO note in test/build.js), and tests that de-duplicated modules are handled correctly.

Handling de-duped modules was broken prior to b4fb18f89a8f79e591819276aced9c78903149eb. If you had two files with the same contents, Browserify would bundle the first file as-is, and the second module would be replaced with a reference to the first module. Browserify-incremental would cache this link. If you then updated the first module, Browserify-incremental wouldn't invalidate the cache of the second module. But as of 3.0.0, Browserify-incremental's cache is populated before Browserify's dedupe transform, so the issue is fixed now. Good to have a test for it anyway. (I'd originally written the test before it was fixed.)
