### PR TITLE
resume bundleStream after attaching cache hooks

### DIFF
--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -73,7 +73,11 @@ function removeCacheBlocker(b) {
 function attachCacheHooksToPipeline(b) {
   var prevBundle = b.bundle;
   b.bundle = function(cb) {
-    var outputStream = through.obj();
+    // The `resume` is there because we need to have this stream
+    // in a "flowing" mode in case a callback is provided to the
+    // original `bundle` method. Otherwise the internal stream buffer
+    // may fill up preventing the "end" event from being fired.
+    var outputStream = through.obj().resume();
 
     invalidateCacheBeforeBundling(b, function(err) {
       if (err) return outputStream.emit('error', err);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "browserify": "^9.0.3",
+    "browserify": "^13.0.0",
     "eslint": "2.4.0",
     "rimraf": "^2.5.2",
     "tap": "^5.7.0"

--- a/test/build.js
+++ b/test/build.js
@@ -13,7 +13,7 @@ var dependentFile = path.join(testUtils.testOutputDir, 'dependent.txt');
 // currently it tests that cache is used, and also that dependencies from the
 // 'transform' event are used for invalidating cache
 test('make sure it builds a valid bundle when using cache', function(t) {
-  t.plan(11);
+  t.plan(12);
 
   testUtils.cleanupTestOutputDir((err) => {
     t.notOk(err, 'clean up test output dir');
@@ -81,7 +81,16 @@ test('make sure it builds a valid bundle when using cache', function(t) {
         t.ok(true, 'built thrice');
         var build3 = fs.readFileSync(path.join(testUtils.testOutputDir, 'build3.js'), 'utf8');
         t.ok(build3.indexOf('foobar2') >= 0, 'bundle has new contents');
-        t.end();
+
+        testUtils.waitForMtimeTick(build4);
+      });
+  }
+
+  function build4() {
+    testUtils.makeBrowserify()
+      .require('browserify')
+      .bundle(function() {
+        t.ok(true, 'bundle callback called');
       });
   }
 });


### PR DESCRIPTION
When callback is provided to the original bundle, the `'end'` event is never fired. Proposal to add a `.resume()` to the stream.
