### PR TITLE
Invalidate cache if mtime changes at all in either direction

### DIFF
--- a/lib/invalidateModifiedFiles.js
+++ b/lib/invalidateModifiedFiles.js
@@ -13,7 +13,7 @@ function invalidateModifiedFiles(mtimes, files, invalidate, done) {
         return fileDone();
       }
       var mtimeNew = stat.mtime.getTime();
-      if (!(mtimes[file] && mtimeNew && mtimeNew <= mtimes[file])) {
+      if (!(mtimes[file] && mtimeNew && mtimeNew == mtimes[file])) {
         invalidate(file);
         invalidated.push(file);
       }


### PR DESCRIPTION
Invalidate the cache when the mtime changes at all, not just when it increases. Fixes https://github.com/jsdf/browserify-incremental/issues/35
