### PR TITLE
Handle streams without backing files.

### DIFF
--- a/lib/BrowserifyCache.js
+++ b/lib/BrowserifyCache.js
@@ -93,7 +93,7 @@ function attachCacheHooksToPipeline(b) {
 function invalidateCacheBeforeBundling(b, done) {
   var cache = BrowserifyCache.getCache(b);
 
-  invalidateCache(cache.mtimes, cache.modules, function(err, invalidated, deleted) {
+  invalidateCache(b, cache.mtimes, cache.modules, function(err, invalidated, deleted) {
     invalidateDependentFiles(cache, [].concat(invalidated, deleted), function(err) {
       b.emit('changedDeps', invalidated, deleted);
       done(err, invalidated);

--- a/lib/invalidateCache.js
+++ b/lib/invalidateCache.js
@@ -1,12 +1,46 @@
 var assertExists = require('./assertExists');
 var invalidateModifiedFiles = require('./invalidateModifiedFiles');
 
-function invalidateCache(mtimes, cache, done) {
+function invalidateCache(b, mtimes, cache, done) {
   assertExists(mtimes);
 
   invalidateModifiedFiles(mtimes, Object.keys(cache), function(file) {
     delete cache[file];
-  }, done);
+  }, function (file) {
+    return invalidateModifiedStream(b, cache, file)
+  }, function(err, invalidated, deleted) {
+    if (deferedQueue.length > 0) {
+      b.on('_ready', function () {
+        invalidated = invalidated.concat(deferedQueue.filter(function (file) {
+          return invalidateModifiedStream(b, cache, file)
+        }))
+        done(err, invalidated, deleted)
+      })
+
+      return
+    }
+
+    done(err, invalidated, deleted)
+  });
+}
+
+var deferedQueue = [];
+function invalidateModifiedStream(b, cache, file) {
+  if (b._pending > 0) {
+    deferedQueue.push(file);
+    return false;
+  }
+
+  var record = b._recorded.find(function (record) {
+    return record.file == file;
+  })
+
+  if (cache[file].source != record.source) {
+    delete cache[file];
+    return true;
+  }
+
+  return false;
 }
 
 module.exports = invalidateCache;

--- a/lib/invalidateDependentFiles.js
+++ b/lib/invalidateDependentFiles.js
@@ -22,7 +22,7 @@ function invalidateDependentFiles(cache, invalidatedModules, done) {
     Object.keys(dependentFiles[dependentFile]).forEach(function(module) {
       delete cache.modules[module];
     });
-  }, function(err) { done(err); });
+  }, null, function(err) { done(err); });
 }
 
 module.exports = invalidateDependentFiles;

--- a/lib/invalidateModifiedFiles.js
+++ b/lib/invalidateModifiedFiles.js
@@ -3,13 +3,20 @@ var async = require('async');
 
 var CONCURRENCY_LIMIT = 40;
 
-function invalidateModifiedFiles(mtimes, files, invalidate, done) {
+function invalidateModifiedFiles(mtimes, files, invalidate, defer, done) {
   var invalidated = [];
   var deleted = [];
   async.eachLimit(files, CONCURRENCY_LIMIT, function(file, fileDone) {
     fs.stat(file, function(err, stat) {
       if (err) {
-        deleted.push(file);
+        // If the cache doesn't have any modification times it's a stream
+        if (!mtimes[file] && defer) {
+          if (defer(file)) {
+            invalidated.push(file)
+          }
+        } else {
+          deleted.push(file);
+        }
         return fileDone();
       }
       var mtimeNew = stat.mtime.getTime();


### PR DESCRIPTION
This handles stream entries that were passed without a backing file and so do not have a modified time by comparing the contents of the steam once browserify has read it. This is especially useful when using browserify-incremental with gulp.